### PR TITLE
Override the right entry point for Active Record 8.1

### DIFF
--- a/lib/ar_transaction_changes.rb
+++ b/lib/ar_transaction_changes.rb
@@ -4,6 +4,12 @@ require "ar_transaction_changes/version"
 require "active_record"
 
 module ArTransactionChanges
+  def self.included(base)
+    if !base._commit_callbacks.empty? || !base._rollback_callbacks.empty?
+      raise "ArTransactionChanges must be included before defining any after_commit or after_rollback callbacks"
+    end
+  end
+
   if ActiveRecord.version >= Gem::Version.new('8.1.0.alpha')
     def _run_commit_callbacks!
       super

--- a/lib/ar_transaction_changes.rb
+++ b/lib/ar_transaction_changes.rb
@@ -4,16 +4,30 @@ require "ar_transaction_changes/version"
 require "active_record"
 
 module ArTransactionChanges
-  def _run_commit_callbacks
-    super
-  ensure
-    @transaction_changed_attributes = nil
-  end
+  if ActiveRecord.version >= Gem::Version.new('8.1.0.alpha')
+    def _run_commit_callbacks!
+      super
+    ensure
+      @transaction_changed_attributes = nil
+    end
 
-  def _run_rollback_callbacks
-    super
-  ensure
-    @transaction_changed_attributes = nil
+    def _run_rollback_callbacks!
+      super
+    ensure
+      @transaction_changed_attributes = nil
+    end
+  else
+    def _run_commit_callbacks
+      super
+    ensure
+      @transaction_changed_attributes = nil
+    end
+
+    def _run_rollback_callbacks
+      super
+    ensure
+      @transaction_changed_attributes = nil
+    end
   end
 
   def transaction_changed_attributes

--- a/test/transaction_changes_test.rb
+++ b/test/transaction_changes_test.rb
@@ -174,4 +174,28 @@ class TransactionChangesTest < Minitest::Test
 
     assert_equal [[], ['a', 'b']], @user.stored_transaction_changes['notes']
   end
+
+  def test_do_not_allow_adding_this_gem_to_a_model_after_commit_callbacks_are_defined
+    assert_raises(RuntimeError) do
+      Class.new(ActiveRecord::Base) do
+        after_commit :some_method
+
+        include ArTransactionChanges
+
+        def some_method; end
+      end
+    end
+  end
+
+    def test_do_not_allow_adding_this_gem_to_a_model_after_rollback_callbacks_are_defined
+    assert_raises(RuntimeError) do
+      Class.new(ActiveRecord::Base) do
+        after_rollback :some_method
+
+        include ArTransactionChanges
+
+        def some_method; end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Since https://github.com/rails/rails/commit/207a254cedef2c381c2898bac960b91ce14ab3a7 the implementation of what was before `_run_commit_callbacks` and `_run_rollback_callbacks` has changed to `_run_commit_callbacks!` and
`_run_rollback_callbacks!` respectively.

When the callbacks are first called in a class, the `_run_commit_callbacks` and `_run_rollback_callbacks methods` are defined to point to the new implementations with the exclamation mark, and that doesn't trigger any of the `run_#{callback}_callbacks` methods defined in the inheritance chain. Therefore, we need to override the right methods depending on the Active Record version.