### PR TITLE
Patch run_callbacks instead

### DIFF
--- a/lib/ar_transaction_changes.rb
+++ b/lib/ar_transaction_changes.rb
@@ -4,37 +4,21 @@ require "ar_transaction_changes/version"
 require "active_record"
 
 module ArTransactionChanges
-  def self.included(base)
-    if base.respond_to?(:_commit_callbacks) && base.respond_to?(:_rollback_callbacks)
-      if !base._commit_callbacks.empty? || !base._rollback_callbacks.empty?
-        raise "ArTransactionChanges must be included before defining any after_commit or after_rollback callbacks"
+  if ActiveRecord.version >= Gem::Version.new('7.1')
+    def run_callbacks(kind, type = nil)
+      super
+    ensure
+      if kind == :commit || kind == :rollback
+        @transaction_changed_attributes = nil
       end
     end
-  end
-
-  if ActiveRecord.version >= Gem::Version.new('8.1.0.alpha')
-    def _run_commit_callbacks!
-      super
-    ensure
-      @transaction_changed_attributes = nil
-    end
-
-    def _run_rollback_callbacks!
-      super
-    ensure
-      @transaction_changed_attributes = nil
-    end
   else
-    def _run_commit_callbacks
+    def run_callbacks(kind)
       super
     ensure
-      @transaction_changed_attributes = nil
-    end
-
-    def _run_rollback_callbacks
-      super
-    ensure
-      @transaction_changed_attributes = nil
+      if kind == :commit || kind == :rollback
+        @transaction_changed_attributes = nil
+      end
     end
   end
 

--- a/lib/ar_transaction_changes.rb
+++ b/lib/ar_transaction_changes.rb
@@ -12,6 +12,22 @@ module ArTransactionChanges
         @transaction_changed_attributes = nil
       end
     end
+
+    if ActiveRecord.version >= Gem::Version.new('8.1.0.alpha')
+      # We should reset @transaction_changed_attributes in the no-op version of the method.
+      # Even if there are no callbacks registered, attributes should be reset on commit/rollback.
+      def _run_commit_callbacks
+        super
+      ensure
+        @transaction_changed_attributes = nil
+      end
+
+      def _run_rollback_callbacks
+        super
+      ensure
+        @transaction_changed_attributes = nil
+      end
+    end
   else
     def run_callbacks(kind)
       super

--- a/test/transaction_changes_test.rb
+++ b/test/transaction_changes_test.rb
@@ -174,28 +174,4 @@ class TransactionChangesTest < Minitest::Test
 
     assert_equal [[], ['a', 'b']], @user.stored_transaction_changes['notes']
   end
-
-  def test_do_not_allow_adding_this_gem_to_a_model_after_commit_callbacks_are_defined
-    assert_raises(RuntimeError) do
-      Class.new(ActiveRecord::Base) do
-        after_commit :some_method
-
-        include ArTransactionChanges
-
-        def some_method; end
-      end
-    end
-  end
-
-    def test_do_not_allow_adding_this_gem_to_a_model_after_rollback_callbacks_are_defined
-    assert_raises(RuntimeError) do
-      Class.new(ActiveRecord::Base) do
-        after_rollback :some_method
-
-        include ArTransactionChanges
-
-        def some_method; end
-      end
-    end
-  end
 end


### PR DESCRIPTION
Handle changes to Rails' callback code (https://github.com/rails/rails/commit/207a254cedef2c381c2898bac960b91ce14ab3a7), which introduces a "fast path" for callbacks and no-ops the `_run_#{callback}_callbacks` methods up until the point where a callback is actually defined, at which point Rails aliases `_run_#{callback}_callbacks`  to a `!` version of the method. 

Rather than patching the `!` version of the callbacks, we patch the `run_callbacks` method. This way, we don't need to worry about callbacks potentially being defined _before_ we include the gem, which can lead to Rails aliasing the non-patched version of the `_run_#{callback}_callbacks!` methods.

Plus, `run_callbacks` is public API, so it's better to patch this anyways.